### PR TITLE
Implement ApiCall function, '/quest' get and post routes

### DIFF
--- a/apicall.js
+++ b/apicall.js
@@ -10,14 +10,35 @@ const searchRequest = {
   location: 'san francisco, ca'
 };
 
-yelp.accessToken(clientId, clientSecret).then(response => {
-  const client = yelp.client(response.jsonBody.access_token);
+// yelp.accessToken(clientId, clientSecret).then(response => {
+//   const client = yelp.client(response.jsonBody.access_token);
 
-  client.search(searchRequest).then(response => {
-    const allResults = response.jsonBody.businesses; //this will put all businesses in the location above into allresults
-    const prettyJson = JSON.stringify(allResults, null, 4);
-    console.log(prettyJson);
-  });
-}).catch(e => {
-  console.log(e);
-});
+//   client.search(searchRequest).then(response => {
+//     const allResults = response.jsonBody.businesses; //this will put all businesses in the location above into allresults
+//     const prettyJson = JSON.stringify(allResults, null, 4);
+//     console.log(prettyJson);
+//   });
+// }).catch(e => {
+//   console.log(e);
+// });
+
+//insert token here
+const token = "";
+
+const ApiCall = function(req, res) {
+  const location = req.body.zip ? req.body.zip : 94105;
+  const categories = req.body.categories ? req.body.categories : "italian";
+  const client = yelp.client(token);
+  
+  client.search({
+    location: location,
+    categories: categories
+  }).then(response => {
+    allResults = response.jsonBody.businesses;
+    res.send(allResults.slice(0,3));
+  }).catch(e => {
+    res.send(e)
+  })
+}
+
+module.exports = ApiCall;

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ var app = express();
 var bodyParser = require('body-parser');
 var morgan = require('morgan');
 var path = require('path');
+var ApiCall = require('./../apicall.js');
 
 app.use(express.static(path.join(__dirname, '../client/')));
 app.use(express.static(path.join(__dirname, '../db/')));
@@ -20,6 +21,14 @@ app.post('/', function (req, res) {
   console.log('*** req.body *** >server.js --> ', req.body);
   // res.send('POST request received inside server.js');
   res.send(req.body);
+});
+
+app.get('/quest', function (req, res) {
+  ApiCall(req, res);
+})
+
+app.post('/quest', function (req, res) {
+  ApiCall(req, res);
 });
 
 app.listen(port, function () {


### PR DESCRIPTION
- Refactored the function inside ApiCall.js to be usable in another file.
- exported ApiCall, imported the function into server/server.js

- set up app.get('/quest) route
- set up app.post('/quest) route

- a get request to localhost:3000/quest will return a JSON object (array), which will be a list of 3 restaurants.
- a post request to localhost:3000/quest is expecting 2 keys, a zip (5 digits) and categories (a string of one or more categories, separated by commas)